### PR TITLE
Add retry logic to the call to create a scheduled recording

### DIFF
--- a/PanoptoScheduleUploader.Services/SessionManagementWrapper.cs
+++ b/PanoptoScheduleUploader.Services/SessionManagementWrapper.cs
@@ -136,7 +136,7 @@ namespace PanoptoScheduleUploader.Services
             {
                 this.surpassThreshhold = true;
             }
-            else if (response.TotalNumberResults > RESULTS_PER_PAGE)
+            else
             {
                 while (totalNumberResults >= ((pageNumber) * RESULTS_PER_PAGE))
                 {

--- a/PanoptoScheduleUploader.UI/MainWindow.xaml
+++ b/PanoptoScheduleUploader.UI/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:c="http://schemas.xceed.com/wpf/xaml/toolkit"
-        Title="Upload Schedule" Height="655" Width="1180" ResizeMode="NoResize" Icon="arrow_up.ico">
+        Title="Upload Schedule" Height="655" Width="1180" Icon="arrow_up.ico">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="533*"/>
@@ -24,9 +24,9 @@
                 <Button Content="Verify Login" Height="23" Name="VerifyLogin_Button" Margin="5,20,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Width="100" Click="verifyLogin_Click"/>
             </StackPanel>
             <StackPanel>
-                <TabControl Margin="-5,0,4,0" Height="430">
+                <TabControl Margin="0,0,4,0" Height="430">
                     <TabItem Header="Batch Scheduler">
-                        <StackPanel Orientation="Vertical" Height="450">
+                        <StackPanel Orientation="Vertical" Height="400">
                             <StackPanel Orientation="Horizontal" Margin="0,20,0,0">
                                 <Label Content="File" Width="100" Height="28" HorizontalAlignment="Left" x:Name="label3" VerticalAlignment="Top" />
                                 <TextBox Height="23" HorizontalAlignment="Left" x:Name="fileInput" VerticalAlignment="Top" Width="309" IsReadOnly="True"/>
@@ -37,8 +37,8 @@
                                 <Button Content="Submit" Height="23" Name="submitButton" Margin="10,20,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Width="75" Click="submitButton_Click" />
                             </StackPanel>
                             <Grid Margin="0,20,0,0">
-                                <DataGrid x:Name="previewGrid" HorizontalAlignment="Center" VerticalAlignment="Top" Height="330" Width="800" ItemsSource="{Binding}" ColumnWidth="Auto" />
-                                <ScrollViewer Height="330" HorizontalAlignment="Left" VerticalAlignment="Top" Width="830" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                                <DataGrid x:Name="previewGrid" HorizontalAlignment="Center" VerticalAlignment="Top" Height="280" Width="800" ItemsSource="{Binding}" ColumnWidth="Auto" />
+                                <ScrollViewer Height="280" HorizontalAlignment="Left" VerticalAlignment="Top" Width="830" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                                     <TextBlock Name="resultsTextBlock" Text="" TextWrapping="Wrap" Width="800" />
                                 </ScrollViewer>
                             </Grid>

--- a/PanoptoScheduleUploader.UI/MainWindow.xaml
+++ b/PanoptoScheduleUploader.UI/MainWindow.xaml
@@ -38,7 +38,7 @@
                             </StackPanel>
                             <Grid Margin="0,20,0,0">
                                 <DataGrid x:Name="previewGrid" HorizontalAlignment="Center" VerticalAlignment="Top" Height="280" Width="800" ItemsSource="{Binding}" ColumnWidth="Auto" />
-                                <ScrollViewer Height="280" HorizontalAlignment="Left" VerticalAlignment="Top" Width="830" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                                <ScrollViewer x:Name="resultsContainer" Visibility="Hidden" Height="280" HorizontalAlignment="Left" VerticalAlignment="Top" Width="830" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                                     <TextBlock Name="resultsTextBlock" Text="" TextWrapping="Wrap" Width="800" />
                                 </ScrollViewer>
                             </Grid>

--- a/PanoptoScheduleUploader.UI/MainWindow.xaml.cs
+++ b/PanoptoScheduleUploader.UI/MainWindow.xaml.cs
@@ -63,6 +63,7 @@ namespace PanoptoScheduleUploader.UI
                 // Open document 
                 fileInput.Text = dlg.FileName;
                 previewGrid.Visibility = System.Windows.Visibility.Visible;
+                resultsContainer.Visibility = Visibility.Hidden;
                 try
                 {
                     previewGrid.DataContext = PreviewTable(fileInput.Text);
@@ -137,6 +138,7 @@ namespace PanoptoScheduleUploader.UI
         private void submitButton_Click(object sender, RoutedEventArgs e)
         {
             previewGrid.Visibility = System.Windows.Visibility.Hidden;
+            resultsContainer.Visibility = Visibility.Visible;
             resultsTextBlock.Text = "";
             submitButton.IsEnabled = false;
 


### PR DESCRIPTION
This adds some retry logic to the call to create a scheduled recording. We often see deadlocks on the server when creating a scheduled recording, so this adds logic that tries to detect if the failure was due to a deadlock and retries only in that case. It retries a maximum of three times.

There is also a small amount of UI cleanup so that the last line of text is no longer cut off.